### PR TITLE
Support CircleCI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'rake'
 gem 'awspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
     jmespath (1.3.1)
     json (1.8.3)
     minitest (5.9.0)
+    rake (11.2.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -59,6 +60,7 @@ PLATFORMS
 
 DEPENDENCIES
   awspec
+  rake
 
 BUNDLED WITH
    1.12.5

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 tomohiro.me
 ================================================================================
 
-My domain's records configuration with AWS Route53 by Terraform
+My domain configuration with AWS by Terraform
 
 
 Requirements

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,4 @@
 ---
 machine:
-  version: trusty-621-53170ea
   ruby:
     version: ruby-2.3.1

--- a/circle.yml
+++ b/circle.yml
@@ -2,3 +2,7 @@
 machine:
   ruby:
     version: ruby-2.3.1
+
+test:
+  post:
+    - bundle exec rake spec

--- a/circle.yml
+++ b/circle.yml
@@ -4,5 +4,5 @@ machine:
     version: ruby-2.3.1
 
 test:
-  post:
+  override:
     - bundle exec rake spec

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,5 @@
+---
+machine:
+  version: trusty-621-53170ea
+  ruby:
+    version: ruby-2.3.1

--- a/spec/dns_spec.rb
+++ b/spec/dns_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe route53_hosted_zone('tomohiro.me.') do
+  it { should exist }
+  its(:resource_record_set_count) { should eq 6 }
+
+  it { should have_record_set('tomohiro.me.').ns("ns-1300.awsdns-34.org.\nns-1626.awsdns-11.co.uk.\nns-354.awsdns-44.com.\nns-559.awsdns-05.net.").ttl(172800) }
+  it { should have_record_set('tomohiro.me.').soa('ns-1300.awsdns-34.org. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400').ttl(900) }
+
+  it { should have_record_set('tomohiro.me.').alias('d2tgkw4lnafrdv.cloudfront.net.', 'Z2FDTNDATAQYW2') }
+  it { should have_record_set('www.tomohiro.me.').alias('d2tgkw4lnafrdv.cloudfront.net.', 'Z2FDTNDATAQYW2') }
+  it { should have_record_set('_keybase.tomohiro.me.').txt('"keybase-site-verification=Poyjvel7Sxt5__4im0nOGQyhurCNpumUXF5YEt_OkwQ"').ttl(300) }
+  it { should have_record_set('znc.tomohiro.me.').a('128.199.91.91').ttl(300) }
+end


### PR DESCRIPTION
Enable CircleCI as CI to testing AWS resource by awspec.
- [Sample circle.yml file - CircleCI](https://circleci.com/docs/config-sample/)
- [Ubuntu 14.04 (Trusty) - CircleCI](https://circleci.com/docs/build-image-trusty/)

CircleCI project is here: https://circleci.com/gh/Tomohiro/tomohiro.me
